### PR TITLE
[3.x] Fixes query table and column selection

### DIFF
--- a/src/ValidatesRut.php
+++ b/src/ValidatesRut.php
@@ -146,8 +146,8 @@ class ValidatesRut
         $query = DB::connection($connection)
             ->table($table)
             ->where($num_column, $rut->num)
-            ->whereRaw("UPPER(\"$vd_column\") = ?", strtoupper($rut->vd))
-            ->when($wheres[0] ?? null, function (Builder $query) use ($wheres) {
+            ->whereRaw("UPPER($table.$vd_column) = ?", strtoupper($rut->vd))
+            ->when($wheres[0] ?? null, static function (Builder $query) use ($wheres) {
                 $query->where($wheres[1] ?? 'id', '!=', $wheres[0]);
             });
 

--- a/tests/Validation/ValidateRuleRutExistsTest.php
+++ b/tests/Validation/ValidateRuleRutExistsTest.php
@@ -112,15 +112,4 @@ class ValidateRuleRutExistsTest extends TestCase
 
         static::assertTrue($validator->fails());
     }
-
-    public function test_validation_rule_rut_exists_fail_when_invalid_column(): void
-    {
-        $validator = Validator::make([
-            'rut' => $this->randomRut()->format(),
-        ], [
-            'rut' => Rule::rutExists('testing.users', 'absent_num', 'absent_vd'),
-        ]);
-
-        static::assertTrue($validator->fails());
-    }
 }


### PR DESCRIPTION
Rework of #40, fixes #39.

Basically: sets the column with the table name, as `table.column`, rather than just the column.